### PR TITLE
Minimal dependency upgrade

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.vscode/settings.json
+student-cdc-relay/.vscode/*
+student-cdc-relay/target/*
+student-cdc-relay/logs/*

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Blog URL: https://medium.com/@sohan_ganapathy/change-data-capture-cdc-with-embed
 Once the prerequisites are installed, run the command.
 
 ```shell
+export DEBEZIUM_VERSION=2.4
+export DEBEZIUM_CONNECTOR_VERSION=2.4.0.Alpha2
 docker-compose up -d
 ```
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,13 +4,19 @@ services:
   # Install postgres and setup the student database.
   postgres:
     container_name: postgres
-    image: debezium/postgres
+    image: quay.io/debezium/example-postgres:${DEBEZIUM_VERSION}
     ports:
       - 5432:5432
+    healthcheck:
+      test: "pg_isready -U user -d studentdb"
+      interval: 2s
+      timeout: 20s
+      retries: 10
     environment:
       - POSTGRES_DB=studentdb
       - POSTGRES_USER=user
       - POSTGRES_PASSWORD=password
+      - PGPASSWORD=postgrespw      
 
   # Install Elasticsearch.
   elasticsearch:

--- a/student-cdc-relay/pom.xml
+++ b/student-cdc-relay/pom.xml
@@ -12,8 +12,10 @@
 
     <!-- Properties for the project and its Dependencies -->
     <properties>
-        <java.version>1.8</java.version>
-        <debezium.version>0.10.0.Final</debezium.version>
+        <maven.compiler.release>11</maven.compiler.release>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+        <debezium.version>2.4.0.Alpha2</debezium.version>
     </properties>
 
     <!-- Spring Boot parent -->
@@ -45,6 +47,11 @@
         <!-- Debezium dependencies-->
         <dependency>
             <groupId>io.debezium</groupId>
+            <artifactId>debezium-api</artifactId>
+            <version>${debezium.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.debezium</groupId>
             <artifactId>debezium-embedded</artifactId>
             <version>${debezium.version}</version>
             <exclusions>
@@ -54,6 +61,49 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <!-- Override actual deps from debezium-embedded that seems incompatible -->
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>connect-api</artifactId>
+            <version>3.6.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-clients</artifactId>
+            <version>3.6.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>connect-runtime</artifactId>
+            <version>3.6.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>connect-json</artifactId>
+            <version>3.6.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>connect-file</artifactId>
+            <version>3.6.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.14.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.16.1</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.16.1</version>
+        </dependency>
+
+
         <dependency>
             <groupId>io.debezium</groupId>
             <artifactId>debezium-connector-postgres</artifactId>
@@ -64,6 +114,8 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
+            <version>1.18.30</version>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 
@@ -72,6 +124,20 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+                <configuration>
+                    <additionalProperties>
+                        <encoding.source>UTF-8</encoding.source>
+                        <encoding.reporting>UTF-8</encoding.reporting>
+                        <java.version>11</java.version>
+                    </additionalProperties>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                            <version>1.18.30</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/student-cdc-relay/src/main/java/com/sohan/student/config/DebeziumConnectorConfig.java
+++ b/student-cdc-relay/src/main/java/com/sohan/student/config/DebeziumConnectorConfig.java
@@ -1,5 +1,7 @@
 package com.sohan.student.config;
 
+import java.util.Properties;
+
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -39,18 +41,23 @@ public class DebeziumConnectorConfig {
      */
     @Bean
     public io.debezium.config.Configuration studentConnector() {
-        return io.debezium.config.Configuration.create()
-                .with("connector.class", "io.debezium.connector.postgresql.PostgresConnector")
-                .with("offset.storage",  "org.apache.kafka.connect.storage.FileOffsetBackingStore")
-                .with("offset.storage.file.filename", "/Users/rbg831/Documents/Sohan/Projects/POC/embedded-debezium/student-cdc-relay/student-offset.dat")
-                .with("offset.flush.interval.ms", 60000)
-                .with("name", "student-postgres-connector")
-                .with("database.server.name", studentDBHost+"-"+studentDBName)
-                .with("database.hostname", studentDBHost)
-                .with("database.port", studentDBPort)
-                .with("database.user", studentDBUserName)
-                .with("database.password", studentDBPassword)
-                .with("database.dbname", studentDBName)
-                .with("table.whitelist", STUDENT_TABLE_NAME).build();
+
+        return io.debezium.config.Configuration.create().
+            with("name", "student-postgres-connector").
+            with("connector.class", "io.debezium.connector.postgresql.PostgresConnector").
+            with("offset.storage", "org.apache.kafka.connect.storage.FileOffsetBackingStore").
+            with("offset.storage.file.filename", "/tmp/offsets.dat").
+            with("offset.flush.interval.ms", "60000").
+            /* begin connector properties */
+            with("database.hostname", studentDBHost).
+            with("database.port", studentDBPort).
+            with("database.user", studentDBUserName).
+            with("database.password", studentDBPassword).
+            with("database.dbname", studentDBName).
+            with("table.whitelist", STUDENT_TABLE_NAME).
+            with("topic.prefix", "my-app-connector").
+            with("slot.name", "my_slot_name02").
+            with("schema.history.internal", "io.debezium.storage.file.history.FileSchemaHistory").
+            with("schema.history.internal.file.filename", "/tmp/schemahistory.dat").build();
     }
 }


### PR DESCRIPTION
Hi! I was searching for a complete example of [Debezium engine with postgres](https://debezium.io/documentation/reference/stable/development/engine.html) and found this old one.

In this PR:
- I update dependency from 0.10 to 2.4 of debezium
- Overwrite version of transient dependencies of debezium-api (i need investigate why)
- Upgrade to java 1.8 to 11 ... and fixing lombok
- This change the code a little
- Maybe add some property not needed (y do a lot of tries)
- Use the same postgres of debezium-examples (with [publication plugin](https://www.postgresql.org/docs/current/sql-createpublication.html))
- Adding ENV variables to start the correct version of docker containers
- Some .gitignore

Later i'll investigate this integration https://docs.spring.io/spring-integration/reference/debezium.html and upgrade spring-boot version.

And maybe some day suggest this repo to debezium-examples where i couldn'f find an example of an engine use.

Thanks.